### PR TITLE
Fix for mail event emiting

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ function parseUnread() {
                 self.emit('mail', mail, seqno, attributes);
                 callback()
               });
+            } else {
+              self.emit('mail',mail,seqno,attributes);
             }
           });
           parser.on("attachment", function (attachment) {


### PR DESCRIPTION
If mailParserOptions.streamAttachments is false, parser will not emit the mail event.
