### PR TITLE
Unbreak attachmentOptions

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ function MailListener(options) {
     this.mailParserOptions.streamAttachments = true;
   }
   this.attachmentOptions = options.attachmentOptions || {};
-  this.attachmentOptions.directory = (options.attachmentOptions.directory ? options.attachmentOptions.directory : '');
+  this.attachmentOptions.directory = (this.attachmentOptions.directory ? this.attachmentOptions.directory : '');
   this.imap = new Imap({
     xoauth2: options.xoauth2,
     user: options.username,


### PR DESCRIPTION
The existing check fails if attachmentOptions isn't set because it looks at options.attachmentOptions, which may be (and in my case is) undefined, not this.attachmentOptions, which is what gets defaulted with {} by the assignment in line 24. This simple change unbreaks things.
