### PR TITLE
Don't store attachments if option is turned off

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ function MailListener(options) {
     this.mailParserOptions.streamAttachments = true;
   }
   this.attachmentOptions = options.attachmentOptions || {};
+  this.attachments = options.attachments || false;
   this.attachmentOptions.directory = (this.attachmentOptions.directory ? this.attachmentOptions.directory : '');
   this.imap = new Imap({
     xoauth2: options.xoauth2,
@@ -91,7 +92,7 @@ function parseUnread() {
           var attributes = null;
 
           parser.on("end", function(mail) {
-            if (!self.mailParserOptions.streamAttachments && mail.attachments) {
+            if (!self.mailParserOptions.streamAttachments && mail.attachments && self.attachments) {
               async.each(mail.attachments, function( attachment, callback) {
                 fs.writeFile(self.attachmentOptions.directory + attachment.generatedFileName, attachment.content, function(err) {
                   if(err) {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
     "name": "mail-listener2",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "description": "Mail listener library for node.js. Get notification when new email arrived.",
     "dependencies": {
-      "imap": "*",
-      "mailparser": "*",
+      "imap": "~0.8.14",
+      "mailparser": "~0.4.6",
       "async": "^0.9.0"
     },
     "repository": {


### PR DESCRIPTION
Also use specific versions of dependencies. Star could really cause problems with breaking API changes
