### PR TITLE
Move the node-imap configuration to the configuration file

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,6 +25,18 @@ function MailListener(options) {
   this.attachments = options.attachments || false;
   this.attachmentOptions.directory = (this.attachmentOptions.directory ? this.attachmentOptions.directory : '');
 
+  if (!options.imap) {
+    options.imap = {
+      xoauth2: options.xoauth2,
+      user: options.username,
+      password: options.password,
+      host: options.host,
+      port: options.port,
+      tls: options.tls,
+      tlsOptions: options.tlsOptions || {}
+    };
+  }
+
   this.imap = new Imap(options.imap);
   this.imap.once('ready', imapReady.bind(this));
   this.imap.once('close', imapClose.bind(this));

--- a/index.js
+++ b/index.js
@@ -24,16 +24,8 @@ function MailListener(options) {
   this.attachmentOptions = options.attachmentOptions || {};
   this.attachments = options.attachments || false;
   this.attachmentOptions.directory = (this.attachmentOptions.directory ? this.attachmentOptions.directory : '');
-  this.imap = new Imap({
-    xoauth2: options.xoauth2,
-    user: options.username,
-    password: options.password,
-    host: options.host,
-    port: options.port,
-    tls: options.tls,
-    tlsOptions: options.tlsOptions || {}
-  });
 
+  this.imap = new Imap(options.imap);
   this.imap.once('ready', imapReady.bind(this));
   this.imap.once('close', imapClose.bind(this));
   this.imap.on('error', imapError.bind(this));

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,7 @@ var MailListener = require("mail-listener2");
 
 var mailListener = new MailListener({
   imap: { // please refer to the node-imap documentation for more details on configuration
-    username: "imap-username",
+    user: "imap-username",
     password: "imap-password",
     host: "imap-host",
     port: 993, // imap port

--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,14 @@ JavaScript Code:
 var MailListener = require("mail-listener2");
 
 var mailListener = new MailListener({
-  username: "imap-username",
-  password: "imap-password",
-  host: "imap-host",
-  port: 993, // imap port
-  tls: true,
-  tlsOptions: { rejectUnauthorized: false },
+  imap: {
+    username: "imap-username",
+    password: "imap-password",
+    host: "imap-host",
+    port: 993, // imap port
+    tls: true,
+    tlsOptions: { rejectUnauthorized: false }
+  },
   mailbox: "INBOX", // mailbox to monitor
   searchFilter: ["UNSEEN", "FLAGGED"], // the search filter being used after an IDLE notification has been retrieved
   markSeen: true, // all fetched email willbe marked as seen and not fetched next time

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ JavaScript Code:
 var MailListener = require("mail-listener2");
 
 var mailListener = new MailListener({
-  imap: {
+  imap: { // please refer to the node-imap documentation for more details on configuration
     username: "imap-username",
     password: "imap-password",
     host: "imap-host",

--- a/test.js
+++ b/test.js
@@ -2,7 +2,7 @@ var MailListener = require("./");
 
 var mailListener = new MailListener({
   imap: {
-    username: "xxxx",
+    user: "xxxx",
     password: "xxx",
     host: "imap.gmail.com",
     port: 993,

--- a/test.js
+++ b/test.js
@@ -1,12 +1,14 @@
 var MailListener = require("./");
 
 var mailListener = new MailListener({
-  username: "xxxx",
-  password: "xxx",
-  host: "imap.gmail.com",
-  port: 993,
-  tls: true,
-  tlsOptions: { rejectUnauthorized: false },
+  imap: {
+    username: "xxxx",
+    password: "xxx",
+    host: "imap.gmail.com",
+    port: 993,
+    tls: true,
+    tlsOptions: { rejectUnauthorized: false }
+  },
   mailbox: "INBOX",
   markSeen: true,
   fetchUnreadOnStart: true,


### PR DESCRIPTION
Moving the node-imap configuration to the configuration file:
- lets the user access all the node-imap options
- detaches the code from node-imap, as all the options now reside in the configuration file ; this saves from updating the code every time an option is added or changed

Even though the configuration structure has changed, the code still handles the old structure, for backward compatibility reasons.
