### PR TITLE
Update mail-listener2 with changes from another forks

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,8 @@ function MailListener(options) {
     debug: options.debug || null
   });
 
-  this.imap.once('ready', imapReady.bind(this));
-  this.imap.once('close', imapClose.bind(this));
+  this.imap.on('ready', imapReady.bind(this));
+  this.imap.on('close', imapClose.bind(this));
   this.imap.on('error', imapError.bind(this));
 }
 
@@ -52,6 +52,12 @@ MailListener.prototype.start = function() {
 
 MailListener.prototype.stop = function() {
   this.imap.end();
+};
+
+MailListener.prototype.restart = function() {
+  this.imap.removeAllListeners('mail');
+  this.imap.removeAllListeners('update');
+  this.imap.connect();
 };
 
 function imapReady() {

--- a/index.js
+++ b/index.js
@@ -55,8 +55,11 @@ MailListener.prototype.stop = function() {
 };
 
 MailListener.prototype.restart = function() {
+  console.log('detaching existing listener');
   this.imap.removeAllListeners('mail');
   this.imap.removeAllListeners('update');
+
+  console.log('calling imap connect');
   this.imap.connect();
 };
 

--- a/index.js
+++ b/index.js
@@ -169,6 +169,8 @@ function parseUnread() {
         }
 
       });
+    } else {
+      self.parsingUnread = false;
     }
   });
 }

--- a/index.js
+++ b/index.js
@@ -144,8 +144,8 @@ function parseUnread() {
               callback();
             }
           });
-          parser.on("attachment", function (attachment) {
-            self.emit('attachment', attachment);
+          parser.on("attachment", function (attachment, email) {
+            self.emit('attachment', attachment, email);
           });
           msg.on('body', function(stream, info) {
             stream.on('data', function(chunk) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "imap": "~0.8.14",
     "mailparser": "^0.4.8",
-    "async": "^0.9.0"
+    "async": "^0.9.0",
+    "mime": "^1.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mail-listener2",
-  "version": "0.3.1",
-  "description": "Mail listener library for node.js. Get notification when new email arrived.",
+  "name": "mail-listener2-updated",
+  "version": "0.3.2",
+  "description": "Updated Mail listener library for node.js. Get notification when new email arrived.",
   "dependencies": {
     "imap": "~0.8.14",
     "mailparser": "^0.4.8",
@@ -10,9 +10,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/chirag04/mail-listener2.git"
+    "url": "git://github.com/dapanas/mail-listener2.git"
   },
-  "homepage": "https://github.com/chirag04/mail-listener2",
+  "homepage": "https://github.com/dapanas/mail-listener2",
   "keywords": [
     "mail",
     "job",
@@ -22,9 +22,9 @@
     "email parser"
   ],
   "author": {
-    "name": "Chirag Jain",
-    "email": "jain_chirag04@yahoo.com",
-    "url": "http://chiragjain.tumblr.com"
+    "name": "Daniel Pérez",
+    "email": "dapanas@gmail.com",
+    "url": "http://blogcito.info"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Mail listener library for node.js. Get notification when new email arrived.",
   "dependencies": {
     "imap": "~0.8.14",
-    "mailparser": "~0.4.6",
+    "mailparser": "^0.4.8",
     "async": "^0.9.0"
   },
   "repository": {

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,17 @@
 # Overview
 
-Mail-listener2 library for node.js. Get notification when new email arrived to inbox or when message metadata (e.g. flags) changes externally. Uses IMAP protocol.
+Updated Mail-listener2 library for node.js. Get notification when new email arrived to inbox or when message metadata (e.g. flags) changes externally. Uses IMAP protocol.
+
+Updated Mail-listener2 includes changes and improvements from another forks.
+
+The changes are:
+
+* Avoid to process the same email multiple times
+* Fix unread param on empty response
+* Add a restart function to reconnect to imap server
+* Enhanced logging for the new features
+* Pass email object to attachment event
+* Update mime dependency version to ^1.0.0 because mime 2.0.0 package break the API
 
 We are using these libraries: [node-imap](https://github.com/mscdex/node-imap), [mailparser](https://github.com/andris9/mailparser).
 
@@ -10,7 +21,7 @@ Heavily inspired by [mail-listener](https://github.com/circuithub/mail-listener)
 
 Install
 
-`npm install mail-listener2`
+`npm install mail-listener2-updated`
 
 
 JavaScript Code:
@@ -18,7 +29,7 @@ JavaScript Code:
 
 ```javascript
 
-var MailListener = require("mail-listener2");
+var MailListener = require("mail-listener2-updated");
 
 var mailListener = new MailListener({
   username: "imap-username",
@@ -62,7 +73,7 @@ mailListener.on("mail", function(mail, seqno, attributes){
   // mail processing code goes here
 });
 
-mailListener.on("attachment", function(attachment){
+mailListener.on("attachment", function(attachment, email){
   console.log(attachment.path);
 });
 

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 var MailListener = require("./");
 
 var mailListener = new MailListener({
-  username: "xxxx",
+  username: "xxx",
   password: "xxx",
   host: "imap.gmail.com",
   port: 993,
@@ -22,6 +22,10 @@ mailListener.on("server:connected", function(){
 
 mailListener.on("server:disconnected", function(){
   console.log("imapDisconnected");
+  setTimeout(function() {
+    console.log("Trying to establish imap connection again");
+    mailListener.restart();
+  }, 5* 1000);
 });
 
 mailListener.on("error", function(err){


### PR DESCRIPTION
This pull request includes changes and improvements from another forks.

The changes are:
* Avoid to process the same email multiple times
* Fix unread param on empty response
* Add a restart function to reconnect to imap server
* Enhanced logging for the new features
* Pass email object to _attachment_ event
* Update mime dependency version to ^1.0.0 because mime 2.0.0 package break the API

Every commit was made by me giving the right credit to the original authors.